### PR TITLE
feat: add help output for asdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,6 @@ To build bfs from source, you need to install some [dependencies](https://github
 <strong>Void Linux</strong>
 # xbps-install -S acl-{devel,progs} attr-{devel,progs} libcap-{devel,progs} oniguruma-devel
 
-<strong>FreeBSD</strong>
-# pkg install oniguruma
-
 <strong>MacPorts</strong>
 # port install oniguruma6
 

--- a/bin/help.deps
+++ b/bin/help.deps
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "${current_script_path}")")
+
+# shellcheck source=./lib/utils.bash
+source "${plugin_dir}/lib/utils.bash"
+
+cat <<EOF
+**Dependencies**
+
+** Alpine Linux
+$ apk add acl{,-dev} attr{,-dev} libcap{,-dev} oniguruma-dev
+
+** Arch Linux
+$ pacman -S acl attr libcap oniguruma
+
+** Debian/Ubuntu
+$ apt install acl libacl1-dev attr libattr1-dev libcap2-bin libcap-dev libonig-dev
+
+** Fedora
+$ dnf install acl libacl-devel libattr-devel libcap-devel oniguruma-devel
+
+** NixOS
+$ nix-env -i acl attr libcap oniguruma
+
+** Void Linux
+$ xbps-install -S acl-{devel,progs} attr-{devel,progs} libcap-{devel,progs} oniguruma-devel
+
+** MacPorts
+$ port install oniguruma6
+
+** Homebrew
+$ brew install oniguruma
+
+EOF

--- a/bin/help.links
+++ b/bin/help.links
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "${current_script_path}")")
+
+# shellcheck source=./lib/utils.bash
+source "${plugin_dir}/lib/utils.bash"
+
+cat <<EOF
+- official: https://github.com/tavianator/bfs
+- plugin: https://github.com/virtualroot/asdf-bfs
+EOF

--- a/bin/help.overview
+++ b/bin/help.overview
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "${current_script_path}")")
+
+# shellcheck source=./lib/utils.bash
+source "${plugin_dir}/lib/utils.bash"
+
+cat <<EOF
+bfs:  A breadth-first version of the UNIX find command
+
+asdf install bfs latest
+asdf global bfs latest
+bfs --help
+
+EOF


### PR DESCRIPTION
`asdf help bfs`

```
bfs:  A breadth-first version of the UNIX find command

asdf install bfs latest
asdf global bfs latest
bfs --help

**Dependencies**

** Alpine Linux
$ apk add acl{,-dev} attr{,-dev} libcap{,-dev} oniguruma-dev

** Arch Linux
$ pacman -S acl attr libcap oniguruma

** Debian/Ubuntu
$ apt install acl libacl1-dev attr libattr1-dev libcap2-bin libcap-dev libonig-dev

** Fedora
$ dnf install acl libacl-devel libattr-devel libcap-devel oniguruma-devel

** NixOS
$ nix-env -i acl attr libcap oniguruma

** Void Linux
$ xbps-install -S acl-{devel,progs} attr-{devel,progs} libcap-{devel,progs} oniguruma-devel

** MacPorts
$ port install oniguruma6

** Homebrew
$ brew install oniguruma

- official: https://github.com/tavianator/bfs
- plugin: https://github.com/virtualroot/asdf-bfs
```